### PR TITLE
WAF module syntax unification

### DIFF
--- a/waf/logging.tf
+++ b/waf/logging.tf
@@ -15,21 +15,21 @@ resource "aws_kms_key_policy" "this" {
     Id      = "key-default-1"
     Statement = [
       {
-        "Sid" : "Enable IAM User Permissions",
-        "Effect" : "Allow",
-        "Principal" : {
-          "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-        },
-        "Action" : "kms:*",
-        "Resource" : "*"
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
       },
       {
-        "Sid" : "Allow administration of the key",
-        "Effect" : "Allow",
-        "Principal" : {
-          "AWS" : "${var.kms_admin_iam_arn}"
-        },
-        "Action" : [
+        Sid    = "Allow administration of the key"
+        Effect = "Allow"
+        Principal = {
+          AWS = "${var.kms_admin_iam_arn}"
+        }
+        Action = [
           "kms:ReplicateKey",
           "kms:Create*",
           "kms:Describe*",
@@ -43,10 +43,9 @@ resource "aws_kms_key_policy" "this" {
           "kms:Delete*",
           "kms:ScheduleKeyDeletion",
           "kms:CancelKeyDeletion"
-        ],
-        "Resource" : "*"
+        ]
+        Resource = "*"
       },
-
       {
         Sid    = "Allow CloudWatch Logs to use the key"
         Effect = "Allow"

--- a/waf/variables.tf
+++ b/waf/variables.tf
@@ -1,31 +1,31 @@
 ## REQUIRED VARIABLES ##
 variable "target_arn" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The ARN value of the resource that you want AWS WAF to inspect and protect."
 }
 
 variable "waf_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the WAF"
 }
 
 variable "waf_name" {
-  type    = string
-  default = "waf"
+  type        = string
+  default     = "waf"
   description = "The name of the WAF"
 }
 
 variable "ip_addresses_to_block" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "List of IP addresses to blacklist"
 }
 
 variable "ip_addresses_to_allow" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "List of IP addresses to whitelist"
 }
 
@@ -43,77 +43,67 @@ variable "custom_response_body" {
   description = "Custom response body"
 }
 
-# Variable to enable or disable the allow-ips rule
 variable "allow_ips_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the allow-ips rule"
 }
 
-# Variable to enable or disable the bot control rule
 variable "bot_control_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the bot control rule"
 }
 
-# Variable to enable or disable the IP reputation rule
 variable "ip_reputation_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the IP reputation rule"
 }
 
-# Variable to enable or disable the anonymous IP rule
 variable "anonymous_ip_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the anonymous IP rule"
 }
 
-# Variable to enable or disable the known bad inputs rule
 variable "known_bad_inputs_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the known bad inputs rule"
 }
-
-# Variable to enable or disable the SQL injection rule
 variable "sql_injection_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the SQL injection rule"
 }
 
-# Variable to enable or disable the Unix rule
 variable "unix_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the Unix rule"
 }
 
-# Variable to enable or disable the block-ips rule
 variable "block_ips_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the block-ips rule"
 }
 
-# Variable to enable or disable the rate limit rule
 variable "rate_limit_rule_enabled" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enable or disable the rate limit rule"
 }
 
 variable "rate_limit" {
-  type    = number
-  default = 500 #  30 requests per second (600 requests per 5 minutes)
+  type        = number
+  default     = 500 #  30 requests per second (600 requests per 5 minutes)
   description = "The rate limit value"
 }
 
 variable "kms_admin_iam_arn" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The ARN of the IAM role that will administrate the KMS key"
 }


### PR DESCRIPTION
Use same syntax while encoding JSON objects.
`terraform fmt` changes as well