### PR TITLE
feature/data-handling-tls-enforcement :Enforce TLS 1.2+ on S3 buckets that may hold ePHI

### DIFF
--- a/aws-cloudtrail/module/main.tf
+++ b/aws-cloudtrail/module/main.tf
@@ -193,6 +193,21 @@ resource "aws_s3_bucket_policy" "this" {
         Condition = {
           StringEquals = { "s3:x-amz-acl" = "bucket-owner-full-control" }
         }
+      },
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.this.arn}",
+          "${aws_s3_bucket.this.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
       }
     ]
   })

--- a/aws-cloudtrail/module/main.tf
+++ b/aws-cloudtrail/module/main.tf
@@ -194,6 +194,8 @@ resource "aws_s3_bucket_policy" "this" {
           StringEquals = { "s3:x-amz-acl" = "bucket-owner-full-control" }
         }
       },
+      # HIPAA §164.312(e) — Transmission Security / Encryption: deny access
+      # over plaintext HTTP or outdated TLS.
       {
         Sid       = "DenyInsecureTransport"
         Effect    = "Deny"
@@ -206,6 +208,21 @@ resource "aws_s3_bucket_policy" "this" {
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyOutdatedTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.this.arn}",
+          "${aws_s3_bucket.this.arn}/*"
+        ]
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
           }
         }
       }

--- a/aws-healthlake/module/iam.tf
+++ b/aws-healthlake/module/iam.tf
@@ -109,6 +109,21 @@ resource "aws_s3_bucket_policy" "access_logs" {
             "aws:SourceAccount" = "${data.aws_caller_identity.current.account_id}"
           }
         }
+      },
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.access_logs.arn}",
+          "${aws_s3_bucket.access_logs.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
       }
     ]
   })

--- a/aws-healthlake/module/iam.tf
+++ b/aws-healthlake/module/iam.tf
@@ -110,6 +110,8 @@ resource "aws_s3_bucket_policy" "access_logs" {
           }
         }
       },
+      # HIPAA §164.312(e) — Transmission Security / Encryption: deny access
+      # over plaintext HTTP or outdated TLS.
       {
         Sid       = "DenyInsecureTransport"
         Effect    = "Deny"
@@ -122,6 +124,21 @@ resource "aws_s3_bucket_policy" "access_logs" {
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyOutdatedTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.access_logs.arn}",
+          "${aws_s3_bucket.access_logs.arn}/*"
+        ]
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
           }
         }
       }

--- a/aws-healthlake/module/s3.tf
+++ b/aws-healthlake/module/s3.tf
@@ -62,6 +62,8 @@ resource "aws_s3_bucket_policy" "data" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
+      # HIPAA §164.312(e) — Transmission Security / Encryption: deny access
+      # over plaintext HTTP or outdated TLS.
       {
         Sid       = "DenyInsecureTransport"
         Effect    = "Deny"
@@ -74,6 +76,21 @@ resource "aws_s3_bucket_policy" "data" {
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyOutdatedTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.data.arn}",
+          "${aws_s3_bucket.data.arn}/*"
+        ]
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
           }
         }
       }

--- a/aws-healthlake/module/s3.tf
+++ b/aws-healthlake/module/s3.tf
@@ -56,6 +56,31 @@ resource "aws_s3_bucket_logging" "data" {
   target_prefix = "${aws_s3_bucket.data.bucket}/logs"
 }
 
+resource "aws_s3_bucket_policy" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.data.arn}",
+          "${aws_s3_bucket.data.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
 ################################################################################
 # Access logs bucket
 

--- a/aws-s3/module/iam.tf
+++ b/aws-s3/module/iam.tf
@@ -1,6 +1,31 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.this.arn}",
+          "${aws_s3_bucket.this.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_s3_bucket_policy" "logs" {
   bucket = aws_s3_bucket.logs.id
 
@@ -23,6 +48,21 @@ resource "aws_s3_bucket_policy" "logs" {
           }
           StringEquals = {
             "aws:SourceAccount" = "${data.aws_caller_identity.current.account_id}"
+          }
+        }
+      },
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.logs.arn}",
+          "${aws_s3_bucket.logs.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
           }
         }
       }

--- a/aws-s3/module/iam.tf
+++ b/aws-s3/module/iam.tf
@@ -7,6 +7,8 @@ resource "aws_s3_bucket_policy" "this" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
+      # HIPAA §164.312(e) — Transmission Security / Encryption: deny access
+      # over plaintext HTTP or outdated TLS.
       {
         Sid       = "DenyInsecureTransport"
         Effect    = "Deny"
@@ -19,6 +21,21 @@ resource "aws_s3_bucket_policy" "this" {
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyOutdatedTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.this.arn}",
+          "${aws_s3_bucket.this.arn}/*"
+        ]
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
           }
         }
       }
@@ -51,6 +68,8 @@ resource "aws_s3_bucket_policy" "logs" {
           }
         }
       },
+      # HIPAA §164.312(e) — Transmission Security / Encryption: deny access
+      # over plaintext HTTP or outdated TLS.
       {
         Sid       = "DenyInsecureTransport"
         Effect    = "Deny"
@@ -63,6 +82,21 @@ resource "aws_s3_bucket_policy" "logs" {
         Condition = {
           Bool = {
             "aws:SecureTransport" = "false"
+          }
+        }
+      },
+      {
+        Sid       = "DenyOutdatedTLS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "${aws_s3_bucket.logs.arn}",
+          "${aws_s3_bucket.logs.arn}/*"
+        ]
+        Condition = {
+          NumericLessThan = {
+            "s3:TlsVersion" = "1.2"
           }
         }
       }


### PR DESCRIPTION
## Summary

An automated internal HIPAA compliance review of this repository's Terraform modules from our **GRC XL Framewok (Xmartlabs)**, flagged a transmission-security gap under HIPAA §164.312(e)(1) / (e)(2)(ii)
(Transmission Security; Encryption). We identified that the S3 buckets in
this repository had no bucket policy enforcing encrypted transport, so
AWS's platform default applied — both plaintext HTTP and outdated TLS
versions were accepted.

This PR adds explicit deny statements to close that gap on:
- `aws-healthlake` — the FHIR datastore's import/export bucket and its
  access-logs bucket
- `aws-s3` — the module's main bucket and its logs bucket
- `aws-cloudtrail` — the trail's log bucket

Each affected bucket policy now denies:
1. any request not made over HTTPS, and
2. any request negotiated below TLS 1.2

## Testing

- `terraform fmt -check` — clean on all three touched modules, no
  formatting changes needed.
- `terraform validate` — passes on all three touched modules.
- `checkov` — ran against each touched module. No new findings were
  introduced by this change. Two modules carry pre-existing findings
  unrelated to transport security (`aws-s3`: default KMS encryption not
  enabled by default, gated behind an existing variable; `aws-cloudtrail`:
  missing SNS topic, shorter-than-1-year log retention, no cross-region
  replication, no access logging, no event notifications) — confirmed
  identical before and after this diff, out of scope for this PR.

## Why this matters

This closes a gap relative to the project's own stated goal of encryption
"in transit by default" for HIPAA-compliant infrastructure — at-rest
encryption was already solid across every module checked; this brings
in-transit enforcement up to the same bar.